### PR TITLE
Fix trimming issue preventing patient save

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ dotnet run --project src/VitalDesk.App
 ```bash
 dotnet publish src/VitalDesk.App -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -p:PublishTrimmed=true -p:TrimMode=link -o ./publish/windows-opt
 ```
+**Note:** The application is published with trimming enabled. To ensure that
+Dapper can map data correctly in the trimmed executable, the `Patient` and
+`Vital` model classes preserve their public properties using the
+`[DynamicallyAccessedMembers]` attribute.
 
 ### テスト実行
 ```bash

--- a/src/VitalDesk.Core/Models/Patient.cs
+++ b/src/VitalDesk.Core/Models/Patient.cs
@@ -1,5 +1,10 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace VitalDesk.Core.Models;
 
+// Ensure public properties remain available for reflection when the application
+// is published with trimming (required by Dapper).
+[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)]
 public class Patient
 {
     public int Id { get; set; }

--- a/src/VitalDesk.Core/Models/Vital.cs
+++ b/src/VitalDesk.Core/Models/Vital.cs
@@ -1,5 +1,9 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace VitalDesk.Core.Models;
 
+// Preserve public properties for reflection when trimming the application.
+[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)]
 public class Vital
 {
     public int Id { get; set; }


### PR DESCRIPTION
## Summary
- keep `Patient` and `Vital` properties for reflection when trimmed
- document trimming requirement in README

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684581691e88832384f5e2523b38895e